### PR TITLE
[BUFGIX] unserialize EXT_CONF array when using

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -23,8 +23,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['contentRenderingTemplates'] = array(
 );
 
 	// Minimum set of fields, recommended for beginners, when showMinimumSetOfFields is set to 1 in Extension Manager
-if ($_EXTCONF['showMinimumSetOfFields']) {
-	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
-		'<INCLUDE_TYPOSCRIPT: source="FILE:EXT:contentelements/Configuration/TypoScript/PageTSconfig/minimum.ts">'
-	);
+$extconf = unserialize($_EXTCONF);
+if(is_array($extconf)) {
+	if ($extconf['showMinimumSetOfFields']) {
+		\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
+			'<INCLUDE_TYPOSCRIPT: source="FILE:EXT:contentelements/Configuration/TypoScript/PageTSconfig/minimum.ts">'
+		);
+	}
 }


### PR DESCRIPTION
Unserializes the EXT_CONF array when using the array in
ext_localconf.php.
If the array is not unserialized an illegal string offset exception is
thrown
